### PR TITLE
SCORE website theme

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
           retention-days: 1
           if-no-files-found: error
       - name: Comment artifact URL
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
         run: |
           gh pr comment ${{ github.event.pull_request.number }} \
             --body "Documentation artifact: ${{ steps.upload-artifact-pr.outputs.artifact-url }}"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,12 @@ MODULE.bazel.lock
 
 # Ruff
 .ruff_cache
+
+# Python
+.venv/
+
+# Environments
+.envrc
+
+# Sphinx builds
+_build/

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -11,7 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@pip_sphinx//:requirements.bzl", "requirement")
+load("@pip_sphinx//:requirements.bzl", "all_requirements", "requirement")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_library")
@@ -25,6 +25,7 @@ sphinx_docs(
         "**/*.svg",
         "**/*.rst",
         "**/*.html",
+        "**/*.css",
     ]),
     config = ":conf.py",
     extra_opts = [
@@ -42,9 +43,7 @@ sphinx_docs(
 
 sphinx_build_binary(
     name = "sphinx_build",
-    deps = [
-        requirement("sphinx"),
-    ],
+    deps = all_requirements,
 )
 
 compile_pip_requirements(

--- a/docs/_assets/css/score.css
+++ b/docs/_assets/css/score.css
@@ -1,0 +1,188 @@
+html {
+    --pst-font-size-base: 17px;
+}
+
+.underline {
+    text-decoration: underline;
+}
+
+/*  SCORE specfic colors 
+    A list of available colro variable names for pyData Sphinx Theme can be found at
+    https://pydata-sphinx-theme.readthedocs.io/en/stable/_downloads/565fbb3ecf2b3048f5fb3953890ba176/_color.scss 
+    
+    The base color is TEAL */
+
+
+html[data-theme="light"] {
+    --pst-color-primary: #547980;
+    --pst-color-secondary: #45ADA8;
+    --pst-color-accent: #9DE0AD;
+    --pst-color-target: #E5FCC2;
+    --pst-color-on-surface: #594F4F;
+    --pst-color-on-background: var(--pst-color-secondary);
+    --pst-color-text-muted: #FFFFFF;
+    --pst-color-table-row-zebra-high-bg: #e6e7e8;
+    --pst-color-table-row-hover-bg: var(--pst-color-secondary); /*#d7d6d6;*/
+}
+
+html[data-theme="dark"] {
+    --pst-color-primary: #45ADA8;
+    --pst-color-secondary: #547980;
+    --pst-color-accent: #9DE0AD;
+    --pst-color-target: #E5FCC2;
+    --pst-color-on-surface: #594F4F;
+    --pst-color-on-background: var(--pst-color-secondary);
+    --pst-color-text-muted: #FFFFFF;
+    --pst-color-table-row-zebra-high-bg: #20242b;
+    --pst-color-table-row-hover-bg: var(--pst-color-secondary); /*#30353e;*/
+}
+
+.search-button-field {
+    color: var(--pst-color-primary);
+}
+html .pst-navbar-icon:hover {
+    border-bottom: max(3px,.1875rem,.12em) solid var(--pst-color-primary) !important;
+    color: var(--pst-color-primary) !important;
+  }
+
+.bd-header ul.navbar-nav > li.nav-item.current > .nav-link {
+    color: var(--pst-color-text-muted) !important;
+    font-weight: 900 !important;
+}
+
+.bd-header ul.navbar-nav > li.nav-item > .nav-link:hover {
+    color: var(--pst-color-primary);
+}
+
+ul.navbar-nav li a {
+    color: var(--pst-color-primary);
+  }
+
+.bd-search input.form-control::placeholder,
+.bd-search input.form-control {
+    color: var(--pst-color-primary) !important;
+}
+
+/* Right sidebar */
+.toc-entry a.nav-link {
+    color: var(--pst-color-text-base);
+}
+/* Left, top SCORE brand  */
+.navbar-brand p
+{
+    color: var(--pst-color-text-muted);
+    font-weight: 900;
+}
+.navbar-brand:hover, .navbar-brand:visited:hover {
+    text-decoration: none;
+}
+
+/* GitHub logo for shorten URL  */
+a.github::before {
+    content: var(--pst-icon-github);
+    color: var(--pst-color-text-base);
+}
+a.github {
+    text-decoration: none !important;
+}
+
+/* Left sidebar links */
+nav.bd-links li > a {
+    color: var(--pst-color-text-base);
+}
+
+/* Breadcrumbs, above page content: Link color */
+ul.bd-breadcrumbs li.breadcrumb-item a {
+    color: var(--pst-color-text-base);
+    text-decoration: none;
+}
+
+/* Breadcrumbs, above page content: Arrow color */
+ul.bd-breadcrumbs li.breadcrumb-item:not(.breadcrumb-home)::before {
+    color: var(--pst-color-text-base);
+}
+
+blockquote {
+    color: var(--pst-color-text-base);
+}
+
+.admonition, div.admonition {
+    background-color: rgba(0,0,0,0.1);
+}
+
+/* SCORE Background video
+   Source: https://www.imi21.com/background-video-full-screen.php */
+
+div.score_banner {
+    background-color: var(--pst-color-on-surface);
+}
+#videowrapper{  
+    position: relative;
+    overflow: hidden;
+} 
+
+#fullScreenDiv{
+    height: 300px;
+    width: 100%;
+    padding:0;
+    margin: 0;
+    /* background-color: gray;
+    position: relative; */
+    container-type: inline-size;
+}
+
+#video{    
+    width: 100%; 
+    /* height: auto;
+    margin: auto;
+    display: block; */
+}
+@media (min-aspect-ratio: 16/9) {
+  #video{
+    width: 100%; 
+    height:auto;
+  }
+}
+
+#score-title {
+    width: 100%; 
+    height: 100%;
+    position: absolute; 
+    top: 0; 
+    left: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    color: var(--pst-color-text-base);
+    /* font-size: 4.5em; */
+    font-size: 8.0cqw;
+    font-weight: 900;
+    
+    /* Is somehow cool with image/video title background */
+    /*animation: fadeIn 3s;  */
+}
+
+/* As long as no image or video is shown in
+   the title, this is not needed, but kept 
+   for future needs */
+/* html[data-theme="light"] #score-title {
+    background-color: rgba(0,0,0,0.3);
+}
+html[data-theme="dark"] #score-title {
+    background-color: rgba(0,0,0,0.5);
+} */
+
+#score-subtitle {
+    font-size: 0.4em;
+}
+
+#score-phrase {
+    font-size: 0.3em;
+    font-weight: 400;
+}
+
+@keyframes fadeIn {
+    0% { opacity: 0; }
+    100% { opacity: 1; }
+  }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,5 +34,45 @@ numfig = True
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = "alabaster"
-html_theme_options = {"page_width": "auto", "body_max_width": "1500"}
+html_theme = "pydata_sphinx_theme"  #  "alabaster"
+# html_theme_options = {"page_width": "auto", "body_max_width": "1500"}
+
+html_static_path = ["_assets"]
+html_css_files = [
+    "css/score.css",
+]
+
+html_theme_options = {
+    "external_links": [
+        {"name": "Docs", "url": "https://eclipse-score.github.io/score/"},
+        {
+            "name": "Eclipse",
+            "url": "https://projects.eclipse.org/projects/automotive.score",
+        },
+    ],
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/eclipse-score",
+            "icon": "fa-brands fa-github",
+            "type": "fontawesome",
+        }
+    ],
+    "use_edit_page_button": True,  # https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/source-buttons.html#add-an-edit-button
+    "collapse_navigation": True,
+    "logo": {
+        "text": "Eclipse SCORE",
+    },
+}
+
+html_context = {
+    # "github_url": "https://github.com", # or your GitHub Enterprise site
+    "github_user": "eclipse-score",
+    "github_repo": "eclipse-score.github.io",
+    "github_version": "main",
+    "doc_path": "docs",
+}
+
+# Shows no left sidebar for single files
+# Woraround for bug: https://github.com/pydata/pydata-sphinx-theme/issues/1662#issuecomment-1913672649
+html_sidebars = {"get_involved": []}

--- a/docs/get_involved.rst
+++ b/docs/get_involved.rst
@@ -1,0 +1,73 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2024 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+.. role:: underline
+    :class: underline
+
+Get involved
+============
+
+How to get in contact with SCORE
+--------------------------------
+
+If you want to get into contact with SCORE, these are your primary entry points: 
+
+:Project Mailing List: score-dev@eclipse.org
+
+:Architectural Discussion: `#score-project-open-channel <https://sdvworkinggroup.slack.com/archives/C083Z4VL90B>`__
+
+| **General Information / Alignment regarding SCORE as a basis for distributions & products:** 
+| Contact one of the project leads of SCORE https://projects.eclipse.org/projects/automotive.score/who
+
+The technical HOWTO regarding involvement into SCORE is described here: 
+https://github.com/eclipse-score/score/blob/main/CONTRIBUTION.md
+
+How to get involved into SCORE
+------------------------------
+
+The :underline:`only` way to influence SCORE is TO CONTRIBUTE. Everybody can contribute – SCORE is open.
+
+Active Contributions to the SCORE project are the basis for getting involved. The SCORE Project works according to 
+the Eclipse Project Handbook and has named and elected project leads and committers (see https://projects.eclipse.org/projects/automotive.score/who). 
+Direction of the SCORE project is discussed and decided in the project lead circle, technical direction is created and prediscussed in the tech 
+lead circle. Meeting notes are transparent via the SCORE github organization. (see https://github.com/orgs/eclipse-score/discussions)
+
+We aim to build a safety ready full stack architecture, where components fit to each other in 
+automotive grade Software Quality and performance. To achieve this, we follow a strict feature roadmap and architecture
+and a rigid software development process (publicly available in the SCORE Project Handbook starting end of 2024). 
+
+Contributions to the SCORE project must therefore follow the technical direction of the project and the SCORE 
+architecture. All work in SCORE will therefore follow a "Contribution Request" Process. Features on the roadmap of 
+SCORE are defined, Contribution Requests create the basis for individual contributions from within the SCORE 
+project and also from the outside.
+
+You can make proposals for new features or architectural building blocks besides the active contribution requests. 
+Those will not by default be part of the next release of SCORE, because the SCORE release roadmap will strictly 
+comply with the contribution request structure. 
+We plan to have the initial contribution request structure available in the SCORE GitHub until Q1 / 2025.
+
+We plan to incorporate a staging area for such contributions, but
+in the initial phase of the SCORE project (until end of 2025) the focus will be primarily on building a valid 1.0 
+release. Feel free to reach out via the communication channels above.
+
+If you think about your contribution to SCORE, the Contribution Request overview
+is the best place to start (available on https://github.com/eclipse-score/score/issues starting Q1 / 2025)
+
+Based on successful code contributions to the SCORE roadmap, further steps in involvement (like becoming a committer) 
+will be handled according to the rules of the Eclipse Foundation Project Handbook. We value real code based 
+collaboration and will judge new potential contributors and committers mainly on the validity of their work. Active 
+and sustaining contributions are the basis for the ability to shape SCORE.
+
+Making active code contributions via the contribution request process described in the Project Handbook. The 
+project handbook will be available on the SCORE website until end of 2024.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,8 +12,34 @@
    # SPDX-License-Identifier: Apache-2.0
    # *******************************************************************************
 
+.. raw:: html
+
+   <div style="visibility: hidden;height:0px;">
+
 SCORE (Eclipse Safe Open Vehicle Core)
 ######################################
+
+.. raw:: html
+
+   </div>
+
+.. toctree::
+   :hidden:
+
+   get_involved
+
+.. raw:: html
+
+   <div id="videowrapper">
+      <div id="fullScreenDiv">
+         <div id="score-title"> 
+               Eclipse SCORE
+               <span id="score-subtitle">Eclipse Safe Open Vehicle Core</span>
+               <span id="score-phrase">BUILD THE BEST AUTOMOTIVE RUNTIME SOLUTION ONLY ONCE</span>
+         </div>   
+      </div>
+   </div>
+
 
 Background
 **********
@@ -118,9 +144,9 @@ Roadmap
 
 Here you can find the preliminary roadmap of the project:
 
-  .. image:: _assets/score_roadmap.svg
-     :alt: project roadmap
-     :align: center
+.. image:: _assets/score_roadmap.svg
+   :alt: project roadmap
+   :align: center
 
 
 Please be aware, that this roadmap will be also transfered to the `GitHub project <https://github.com/orgs/eclipse-score/projects/1>`_.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@
 
 Sphinx==8.1.3
 sphinx-needs==4.1.0
+pydata-sphinx-theme==0.16.0

--- a/docs/requirements_lock.txt
+++ b/docs/requirements_lock.txt
@@ -6,6 +6,10 @@
 #
 --extra-index-url https://pypi.org/simple/
 
+accessible-pygments==0.0.5 \
+    --hash=sha256:40918d3e6a2b619ad424cb91e556bd3bd8865443d9f22f1dcdf79e33c8046872 \
+    --hash=sha256:88ae3211e68a1d0b011504b2ffc1691feafce124b845bd072ab6f9f66f34d4b7
+    # via pydata-sphinx-theme
 alabaster==0.7.16 \
     --hash=sha256:75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca3106d58d65 \
     --hash=sha256:b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92
@@ -19,7 +23,13 @@ attrs==24.2.0 \
 babel==2.15.0 \
     --hash=sha256:08706bdad8d0a3413266ab61bd6c34d0c28d6e1e7badf40a2cebe67644e2e1fb \
     --hash=sha256:8daf0e265d05768bc6c7a314cf1321e9a123afc328cc635c18622a2f30a04413
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
+beautifulsoup4==4.12.3 \
+    --hash=sha256:74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051 \
+    --hash=sha256:b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed
+    # via pydata-sphinx-theme
 certifi==2024.7.4 \
     --hash=sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b \
     --hash=sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90
@@ -119,7 +129,9 @@ charset-normalizer==3.3.2 \
 docutils==0.20.1 \
     --hash=sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6 \
     --hash=sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
 idna==3.7 \
     --hash=sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc \
     --hash=sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0
@@ -206,10 +218,17 @@ packaging==24.1 \
     --hash=sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002 \
     --hash=sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124
     # via sphinx
+pydata-sphinx-theme==0.16.0 \
+    --hash=sha256:18c810ee4e67e05281e371e156c1fb5bb0fa1f2747240461b225272f7d8d57d8 \
+    --hash=sha256:721dd26e05fa8b992d66ef545536e6cbe0110afb9865820a08894af1ad6f7707
+    # via -r docs/requirements.txt
 pygments==2.18.0 \
     --hash=sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199 \
     --hash=sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a
-    # via sphinx
+    # via
+    #   accessible-pygments
+    #   pydata-sphinx-theme
+    #   sphinx
 referencing==0.35.1 \
     --hash=sha256:25b42124a6c8b632a425174f24087783efb348a6f1e0008e63cd4466fedf703c \
     --hash=sha256:eda6d3234d62814d1c64e305c1331c9a3a6132da475ab6382eaa997b21ee75de
@@ -325,11 +344,16 @@ snowballstemmer==2.2.0 \
     --hash=sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1 \
     --hash=sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a
     # via sphinx
+soupsieve==2.6 \
+    --hash=sha256:e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb \
+    --hash=sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9
+    # via beautifulsoup4
 sphinx==8.1.3 \
     --hash=sha256:09719015511837b76bf6e03e42eb7595ac8c2e41eeb9c29c5b755c6b677992a2 \
     --hash=sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927
     # via
     #   -r docs/requirements.txt
+    #   pydata-sphinx-theme
     #   sphinx-data-viewer
     #   sphinx-needs
     #   sphinxcontrib-jquery
@@ -369,6 +393,10 @@ sphinxcontrib-serializinghtml==1.1.10 \
     --hash=sha256:326369b8df80a7d2d8d7f99aa5ac577f51ea51556ed974e7716cfd4fca3f6cb7 \
     --hash=sha256:93f3f5dc458b91b192fe10c397e324f262cf163d79f3282c158e8436a2c4511f
     # via sphinx
+typing-extensions==4.12.2 \
+    --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
+    --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8
+    # via pydata-sphinx-theme
 urllib3==2.2.2 \
     --hash=sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472 \
     --hash=sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168


### PR DESCRIPTION
This PR adds the pyData-sphinx-theme to the documentation and sets some colors and visual highlights. The goal is to have pleasant landing page.

**Status**: This PR is in **DRAFT** mode, to discuss certain details.

Issue-ref: resolves #4 

### ToDo
* [ ] Get bazel build running, as it does not copy some important pydata-sphinx-theme to the sandbox
* [ ] Reduce video size (it's 5 MB currently, should be 1 MB)
* [ ] Merge "contribute" content to https://github.com/eclipse-score/score/blob/main/CONTRIBUTION.md (or vice versa)
* [ ] Transform heavy-text content to landing page/focused content (Another PR)
### Build
Currently possible only without bazel and via own python venv:
```
# Install dependencies
python -m venv .venv
source .venv/bin/activate  # linux
pip install -r docs/requirements.txt

# Run documentation build
sphinx-build docs/ docs/_build/html

# Open the build
firefox docs/_build/html/index.hml
```

### Changes
* Uses pyData Sphinx theme
* Changes default theme colors
* Adds Score title video
* Add Contribute page for basic doc setup/infos

### Showcase
#### Current screenshot
Mainly without the video
![image](https://github.com/user-attachments/assets/d8cffeff-6c22-4bca-abff-7d44d1744554)
#### Intitial version
https://github.com/user-attachments/assets/ebda8da8-d56f-48eb-bf81-083732bcd179

![score_website_screenshot](https://github.com/user-attachments/assets/12c0477e-1e40-462a-8eaf-4218edeb30ba)
