### PR TITLE
docs: flattend gh-pages structure

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ html_logo = "_assets/S-CORE_Logo_white.svg"
 
 html_theme_options = {
     "external_links": [
-        {"name": "Docs", "url": "https://eclipse-score.github.io/score/"},
+        {"name": "Docs", "url": "https://eclipse-score.github.io/score/main"},
         {
             "name": "Eclipse",
             "url": "https://projects.eclipse.org/projects/automotive.score",


### PR DESCRIPTION
Flattened folder structure of the published gh-pages

gh-pages/
.................
│─ pr-42/ # PR #42 preview
│─ pr-99/ # PR #99 preview
│─ feature-x/ # Feature branch preview
│─ v17/ # Tagged release
│─ main/ # main branch

This was done in order to ensure proper cleaning ( avoiding race conditions and clutter). Thus the latest code should be referenced from the /main subfolder. Updated the <ref> accordingly.