### PR TITLE
docs: update landing page to recent status

### DIFF
--- a/docs/_assets/css/score.css
+++ b/docs/_assets/css/score.css
@@ -6,7 +6,7 @@ html {
     text-decoration: underline;
 }
 
-/*  SCORE specfic colors 
+/*  S-CORE specfic colors 
     A list of available colro variable names for pyData Sphinx Theme can be found at
     https://pydata-sphinx-theme.readthedocs.io/en/stable/_downloads/565fbb3ecf2b3048f5fb3953890ba176/_color.scss 
     
@@ -75,7 +75,7 @@ ul.navbar-nav li a {
 .toc-entry a.nav-link {
     color: var(--pst-color-text-base);
 }
-/* Left, top SCORE brand  */
+/* Left, top S-CORE brand  */
 .navbar-brand p
 {
     color: var(--pst-color-text-muted);
@@ -118,7 +118,7 @@ blockquote {
     background-color: rgba(0,0,0,0.1);
 }
 
-/* SCORE Background video
+/* S-CORE Background video
    Source: https://www.imi21.com/background-video-full-screen.php */
 
 div.score_banner {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,9 +19,9 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = "SCORE"
+project = "S-CORE"
 copyright = "2024, Score"
-author = "SCORE committers"
+author = "S-CORE committers"
 release = "0.1"
 
 # -- General configuration ---------------------------------------------------

--- a/docs/get_involved.rst
+++ b/docs/get_involved.rst
@@ -42,7 +42,7 @@ The :underline:`only` way to influence S-CORE is TO CONTRIBUTE. Everybody can co
 
 Active Contributions to the S-CORE project are the basis for getting involved. The S-CORE Project works according to 
 the Eclipse Project Handbook and has named and elected project leads and committers (see https://projects.eclipse.org/projects/automotive.score/who). 
-Direction of the S-CORE project is discussed and decided in the project lead circle, technical direction is created and prediscussed in the tech 
+Direction of the S-CORE project is discussed and decided in the project lead circle, technical direction is created and discussed upfront in the tech 
 lead circle. Meeting notes are transparent via the S-CORE github organization. (see https://github.com/orgs/eclipse-score/discussions)
 
 We aim to build a safety ready full stack architecture, where components fit to each other in 

--- a/docs/get_involved.rst
+++ b/docs/get_involved.rst
@@ -20,30 +20,30 @@
 Get involved
 ============
 
-How to get in contact with SCORE
---------------------------------
+How to get in contact with S-CORE
+---------------------------------
 
-If you want to get into contact with SCORE, these are your primary entry points: 
+If you want to get into contact with S-CORE, these are your primary entry points: 
 
 :Project Mailing List: score-dev@eclipse.org
 
 :Architectural Discussion: `#score-project-channel-public <https://sdvworkinggroup.slack.com/archives/C083Z4VL90B>`__
 
-| **General Information / Alignment regarding SCORE as a basis for distributions & products:** 
-| Contact one of the project leads of SCORE https://projects.eclipse.org/projects/automotive.score/who
+| **General Information / Alignment regarding S-CORE as a basis for distributions & products:** 
+| Contact one of the project leads of S-CORE https://projects.eclipse.org/projects/automotive.score/who
 
-The technical HOWTO regarding involvement into SCORE is described here: 
+The technical HOWTO regarding involvement into S-CORE is described here: 
 https://github.com/eclipse-score/score/blob/main/CONTRIBUTION.md
 
-How to get involved into SCORE
-------------------------------
+How to get involved into S-CORE
+-------------------------------
 
-The :underline:`only` way to influence SCORE is TO CONTRIBUTE. Everybody can contribute – SCORE is open.
+The :underline:`only` way to influence S-CORE is TO CONTRIBUTE. Everybody can contribute – S-CORE is open.
 
-Active Contributions to the SCORE project are the basis for getting involved. The SCORE Project works according to 
+Active Contributions to the S-CORE project are the basis for getting involved. The S-CORE Project works according to 
 the Eclipse Project Handbook and has named and elected project leads and committers (see https://projects.eclipse.org/projects/automotive.score/who). 
-Direction of the SCORE project is discussed and decided in the project lead circle, technical direction is created and prediscussed in the tech 
-lead circle. Meeting notes are transparent via the SCORE github organization. (see https://github.com/orgs/eclipse-score/discussions)
+Direction of the S-CORE project is discussed and decided in the project lead circle, technical direction is created and prediscussed in the tech 
+lead circle. Meeting notes are transparent via the S-CORE github organization. (see https://github.com/orgs/eclipse-score/discussions)
 
 We aim to build a safety ready full stack architecture, where components fit to each other in 
 automotive grade Software Quality and performance. To achieve this, we follow a strict
@@ -51,28 +51,28 @@ automotive grade Software Quality and performance. To achieve this, we follow a 
 and a `rigid software development process <https://eclipse-score.github.io/score/process/index.html#process-description>`_
 (currently under development). 
 
-Contributions to the SCORE project must therefore follow the technical direction of the project and the SCORE 
-architecture. All work in SCORE will therefore follow a
+Contributions to the S-CORE project must therefore follow the technical direction of the project and the S-CORE 
+architecture. All work in S-CORE will therefore follow a
 `Contribution Request Guideline <https://eclipse-score.github.io/score/process/guidance/contribution_request/index.html>`_.
-Features on the roadmap of SCORE are defined, Contribution Requests create the basis for individual contributions from
-within the SCORE project and also from the outside.
+Features on the roadmap of S-CORE are defined, Contribution Requests create the basis for individual contributions from
+within the S-CORE project and also from the outside.
 
 You can make proposals for new features or architectural building blocks besides the active contribution requests. 
-Those will not by default be part of the next release of SCORE, because the SCORE release roadmap will strictly 
+Those will not by default be part of the next release of S-CORE, because the S-CORE release roadmap will strictly 
 comply with the contribution request structure. 
-We plan to have the initial contribution request structure available in the SCORE GitHub until Q1 / 2025.
+We plan to have the initial contribution request structure available in the S-CORE GitHub until Q1 / 2025.
 
 We plan to incorporate a staging area for such contributions, but
-in the initial phase of the SCORE project (until end of 2025) the focus will be primarily on building a valid 1.0 
+in the initial phase of the S-CORE project (until end of 2025) the focus will be primarily on building a valid 1.0 
 release. Feel free to reach out via the communication channels above.
 
-If you think about your contribution to SCORE, the `Feature Request overview <https://github.com/orgs/eclipse-score/projects/4/views/1>`_
+If you think about your contribution to S-CORE, the `Feature Request overview <https://github.com/orgs/eclipse-score/projects/4/views/1>`_
 is the best place to start.
 
-Based on successful code contributions to the SCORE roadmap, further steps in involvement (like becoming a committer) 
+Based on successful code contributions to the S-CORE roadmap, further steps in involvement (like becoming a committer) 
 will be handled according to the rules of the Eclipse Foundation Project Handbook.
 We value real code based collaboration and will judge new potential contributors and committers mainly on the validity of their work.
-Active and sustaining contributions are the basis for the ability to shape SCORE.
+Active and sustaining contributions are the basis for the ability to shape S-CORE.
 
 Making active code contributions via the contribution request process described in the
-`SCORE project handbook <https://eclipse-score.github.io/score/platform_management_plan/project_management.html>`_.
+`S-CORE project handbook <https://eclipse-score.github.io/score/platform_management_plan/project_management.html>`_.

--- a/docs/get_involved.rst
+++ b/docs/get_involved.rst
@@ -47,13 +47,13 @@ lead circle. Meeting notes are transparent via the S-CORE github organization. (
 
 We aim to build a safety ready full stack architecture, where components fit to each other in 
 automotive grade Software Quality and performance. To achieve this, we follow a strict
-`feature roadmap and architecture <https://eclipse-score.github.io/score/score_releases/index.html#releases>`_
-and a `rigid software development process <https://eclipse-score.github.io/score/process/index.html#process-description>`_
+`feature roadmap and architecture <https://eclipse-score.github.io/score/main/score_releases/index.html>`_
+and a `rigid software development process <https://eclipse-score.github.io/score/main/process/index.html>`_
 (currently under development). 
 
 Contributions to the S-CORE project must therefore follow the technical direction of the project and the S-CORE 
 architecture. All work in S-CORE will therefore follow a
-`Contribution Request Guideline <https://eclipse-score.github.io/score/process/guidance/contribution_request/index.html>`_.
+`Contribution Request Guideline <https://eclipse-score.github.io/score/main/contribute/contribution_request/contribution_request.html>`_.
 Features on the roadmap of S-CORE are defined, Contribution Requests create the basis for individual contributions from
 within the S-CORE project and also from the outside.
 
@@ -75,4 +75,4 @@ We value real code based collaboration and will judge new potential contributors
 Active and sustaining contributions are the basis for the ability to shape S-CORE.
 
 Making active code contributions via the contribution request process described in the
-`S-CORE project handbook <https://eclipse-score.github.io/score/platform_management_plan/project_management.html>`_.
+`S-CORE project handbook <https://eclipse-score.github.io/score/main/platform_management_plan/project_management.html>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -194,15 +194,13 @@ How we Work
 Meetings
 ========
 
-The following regular meetings (and corresponding meeting minutes) are held as part of the project:
+Regular meetings (and corresponding meeting minutes) are held as part of the project:
 
-- `Project Leader Circle <https://github.com/orgs/eclipse-score/discussions/categories/project-lead-circle>`_
+- `Teams & Circles <https://github.com/orgs/eclipse-score/discussions>`_
 
-- `Technical Leader Circle <https://github.com/orgs/eclipse-score/discussions/categories/technical-leader-circle>`_
+Typically teams and circles meet weekly.
 
-The dates will be announced via the score-dev@eclipse.org mailing list.
-
-We plan to start regular exchange in the scope of the *S-CORE* project in December 2024.
+A public meeting calendar for the *S-CORE* project is in preparation.
 
 Partners
 ========

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,8 +16,8 @@
 
    <div style="visibility: hidden;height:0px;">
 
-SCORE (Eclipse Safe Open Vehicle Core)
-######################################
+S-CORE (Eclipse Safe Open Vehicle Core)
+#######################################
 
 .. raw:: html
 
@@ -123,10 +123,10 @@ The tooling used in this project is depicted in the following figure.
    :align: center
 
 In general, all tooling is made available as open source and comes either from other open source projects
-or is developed in the context of the *SCORE* project. The whole infrastructure is based on a build system called
+or is developed in the context of the *S-CORE* project. The whole infrastructure is based on a build system called
 `bazel <https://bazel.build/>`_. All workflows such as cloning the repositories, building the software,
 generation of documentation, testing and much more are automated using bazel. This provides every project user with
-the same user experience. To start working with bazel in the *SCORE* project, you should check
+the same user experience. To start working with bazel in the *S-CORE* project, you should check
 this `introduction page <https://github.com/eclipse-score/blob/main/README.md>`_.
 
 For documenting the process, requirements and architecture we rely on `sphinx <https://www.sphinx-doc.org/en/master/>`_ and it's extension
@@ -134,11 +134,11 @@ For documenting the process, requirements and architecture we rely on `sphinx <h
 for larger diagrams we use `draw.io <https://github.com/jgraph/drawio-desktop>`_.
 
 We support both C++ and Rust programming languages. Software development is done in both languages. Decision which language to choose is done during
-architecture process. In general, C++ should be used only for the existing modules, that are taken over or referenced by the *SCORE* project.
+architecture process. In general, C++ should be used only for the existing modules, that are taken over or referenced by the *S-CORE* project.
 For new features and components we aim to develop the code mostly in Rust, as it seems to be more suitable for development compliant to ISO 26262:2018.  
 
 We use `gtest/gmock <https://github.com/google/googletest>`_ for unit testing and *ITF (Integration testing framework)* for component and integration tests.
-*ITF* was originally developed by one of the initial partners of the *SCORE* project and provided to the community as open source project. Integration tests
+*ITF* was originally developed by one of the initial partners of the *S-CORE* project and provided to the community as open source project. Integration tests
 are executed both in virtual environment and on the reference hardware. 
 
 Roadmap
@@ -171,7 +171,7 @@ latest in the beginning of 2025.
 Alignment Phase
 ===============
 
-In the *Alignment Phase* the main goal is to align on the feature architecture and requirements of the *SCORE Platform v1.0*.
+In the *Alignment Phase* the main goal is to align on the feature architecture and requirements of the *S-CORE Platform v1.0*.
 Additionally it is important to define the roadmap and the order, in which the features should be implemented.
 
 Development Phase
@@ -202,7 +202,7 @@ The following regular meetings (and corresponding meeting minutes) are held as p
 
 The dates will be announced via the score-dev@eclipse.org mailing list.
 
-We plan to start regular exchange in the scope of the *SCORE* project in December 2024.
+We plan to start regular exchange in the scope of the *S-CORE* project in December 2024.
 
 Partners
 ========

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -151,7 +151,7 @@ Here you can find the preliminary roadmap of the project:
    :align: center
 
 
-Please be aware, that this roadmap will be also transfered to the `GitHub project <https://github.com/orgs/eclipse-score/projects/13>`_.
+Please be aware, that this roadmap will be also transferred to the `GitHub project <https://github.com/orgs/eclipse-score/projects/13>`_.
 Please follow this link to get the latest state of the planning. 
 
 MVP Phase
@@ -162,8 +162,8 @@ The main goals of the *MVP Phase* are following:
 * establish a working infrastructure, that enables every developer of the project to specify
   requirements and architecture, implement code and test it accordingly.
 * set-up project structure, that covers all aspects of the open source software development including
-  cooperation between developers and teams, planning, creation of the roadmaps and coordination meetings.
-* define a software development process compliant to ISO 26262:2018, that is a prerequiste for any other software development in the project.
+  cooperation between developers and teams, planning, creation of the roadmap and coordination meetings.
+* define a software development process compliant to ISO 26262:2018, that is a prerequisite for any other software development in the project.
 
 A lot of preparation was already done in the background, therefore we are quite optimistic to finish the *MVP Phase*
 latest in the beginning of 2025.  
@@ -185,7 +185,7 @@ the interest of the automotive community to the project.
 Series Stability & Evolution Phase
 ==================================
 
-In this phase the project should be in an well established state and accepted by the community. Continious development
+In this phase the project should be in an well established state and accepted by the community. Continuous development
 of the features is taking place.
 
 How we Work

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -126,8 +126,8 @@ In general, all tooling is made available as open source and comes either from o
 or is developed in the context of the *S-CORE* project. The whole infrastructure is based on a build system called
 `bazel <https://bazel.build/>`_. All workflows such as cloning the repositories, building the software,
 generation of documentation, testing and much more are automated using bazel. This provides every project user with
-the same user experience. To start working with bazel in the *S-CORE* project, you should check
-this `introduction page <https://github.com/eclipse-score/blob/main/README.md>`_.
+the same user experience. To start working with bazel in the *S-CORE* project to build software and documentation, 
+you should check this `introduction page <https://github.com/eclipse-score/score/blob/main/README.md>`_.
 
 For documenting the process, requirements and architecture we rely on `sphinx <https://www.sphinx-doc.org/en/master/>`_ and it's extension
 `sphinx-needs <https://www.sphinx-needs.com/>`_. For small diagrams we use `PlantUML sphinx-needs extensions <https://sphinx-needs.readthedocs.io/en/stable/directives/needuml.html>`_,
@@ -151,7 +151,7 @@ Here you can find the preliminary roadmap of the project:
    :align: center
 
 
-Please be aware, that this roadmap will be also transfered to the `GitHub project <https://github.com/orgs/eclipse-score/projects/1>`_.
+Please be aware, that this roadmap will be also transfered to the `GitHub project <https://github.com/orgs/eclipse-score/projects/13>`_.
 Please follow this link to get the latest state of the planning. 
 
 MVP Phase


### PR DESCRIPTION
Modifications are:

- Align wording for S-CORE and not use SCORE in text.
- put proper links to landing page pointing to /score documentation
- removed the info that we start December 2024
- correct typos

Closes: #17